### PR TITLE
Fix: SSRF and RCE correction in Analytics and avatar URL

### DIFF
--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -121,7 +121,19 @@ class UserController extends AbstractController
         }
 
         $url = $request->get('url');
+        // Validation anti-SSRF
+	$parsed = parse_url($url);
+	$host = $parsed['host'] ?? '';
+	$scheme = $parsed['scheme'] ?? '';
 
+	if (!in_array($scheme, ['http', 'https'])) {
+    	   $this->addFlash('error', 'URL scheme not allowed');
+    	   return $this->redirectToRoute('app_user');
+        }
+	if (preg_match('/^(127\.|10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[01])\.|localhost)/i', $host)) {
+    	   $this->addFlash('error', 'Internal URLs are not allowed');
+           return $this->redirectToRoute('app_user');
+        }
         if (empty($url)) {
             $this->addFlash('error', 'URL cannot be empty');
             return $this->redirectToRoute('app_user');

--- a/src/Services/Analytics.php
+++ b/src/Services/Analytics.php
@@ -16,23 +16,29 @@ class Analytics
     /**
      * #VULNERABILITY: Intended vulnerable request (SSRF + RCE in the referer header)
      */
-    public function track(): void {
-        if (!$this->trackingEnabled) {
+    public function track(): void
+    {
+    	if (!$this->trackingEnabled) {
+            return;
+    	}
+
+    	$referer = $_SERVER['HTTP_REFERER'] ?? null;
+    	if (!$referer || !$this->validate($referer)) {
+            return;
+    	}
+
+    	// Vérification que l'URL est bien HTTP/HTTPS et pas interne
+    	$parsed = parse_url($referer);
+    	if (!isset($parsed['scheme']) || !in_array($parsed['scheme'], ['http', 'https'])) {
+            return;
+        }
+        $host = $parsed['host'] ?? '';
+        // Bloquer les adresses internes
+        if (preg_match('/^(127\.|10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[01])\.|localhost)/i', $host)) {
             return;
         }
 
-        // Get the referer header
-        $referer = $_SERVER['HTTP_REFERER'] ?? null;
-        if (!$referer || !$this->validate($referer)) {
-            return;
-        }
-
-        // Call the url with curl to get only the http status code
-        $command = 'curl -k -s -o /dev/null -w "%{http_code}" ' . $referer;
-        $statusCode = shell_exec($command);
-
-        // Log the response status
-        $this->logger->info('Referer URL response status: ' . $statusCode);
+        $this->logger->info('Referer tracked: ' . $referer);
     }
 
     public function validate(string $url): bool


### PR DESCRIPTION
## Vulnerabilities Fixed
- V-04: SSRF on the avatar URL (UserController.php)
- V-11: SSRF + RCE via referrer header (Analytics.php)
- V-12: SSRF + RCE via referrer header (Analytics.php)

## Issue
- Avatar URL: No validation of the URL provided by the user
- Analytics: The Referer header was being passed directly to shell_exec()

allowing command injection + SSRF

## Fix
- Scheme validation (http/https only)
- Blocking of internal IPs (127.x, 10.x, 192.168.x, localhost)
- Removal of shell_exec() in Analytics

## Tests Performed
- http://127.0.0.1:8000 → blocked
- http://192.168.1.1 → blocked
- Valid external URL → Works
- No regression detected