### PR TITLE
Fix: Upload vulnerability corrected - MIME type and extension validation

### DIFF
--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -95,8 +95,22 @@ class UserController extends AbstractController
             mkdir($this->getParameter('avatars_directory'));
         }
 
-        $avatarName = md5(uniqid()) . '.' . $avatar->getClientOriginalExtension();
-        $avatar->move($this->getParameter('avatars_directory'), $avatarName);
+        $allowedMimes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+	$allowedExtensions = ['jpg', 'jpeg', 'png', 'gif', 'webp'];
+
+	if (!in_array($avatar->getMimeType(), $allowedMimes)) {
+    	    $this->addFlash('error', 'File type not allowed. Only images are accepted.');
+    	    return $this->redirectToRoute('app_user');
+	}
+
+	$extension = strtolower($avatar->getClientOriginalExtension());
+	if (!in_array($extension, $allowedExtensions)) {
+            $this->addFlash('error', 'File extension not allowed.');
+    	    return $this->redirectToRoute('app_user');
+	}
+
+	$avatarName = md5(uniqid()) . '.' . $extension;
+	$avatar->move($this->getParameter('avatars_directory'), $avatarName);
 
         $user->setAvatar($avatarName);
         $userRepository->save($user, true);


### PR DESCRIPTION
## Vulnerability Fixed
- V-03: File Upload Without Extension Verification (UserController.php)

## Issue
No validation of the uploaded file type as an avatar,
preventing the uploading of a PHP file and its execution on the server.

## Fix
- MIME type verification (image/jpeg, image/png, image/gif, image/webp)
- File extension verification
- Double validation to prevent workarounds

## Tests Performed
- Upload of shell.php → blocked
- Upload of image.jpg → works
- Upload of image.png → works
- No regressions detected