### PR TITLE
fix: prevent LFI by using whitelist for legal content files

### DIFF
--- a/src/Controller/BlogController.php
+++ b/src/Controller/BlogController.php
@@ -88,10 +88,18 @@ class BlogController extends AbstractController
     #[Route('/legal/content', name: 'app_legal_content', methods: ['GET'])]
     public function legalContent(Request $request): Response
     {
-        $contentPath = __DIR__ . '/../../templates/legal/' . $request->get('p');
-        if (is_dir($contentPath) || !file_exists($contentPath))
-            throw $this->createNotFoundException();
+        $allowedFiles = ['terms.html', 'privacy.html', 'cookies.html'];
+	$page = $request->get('p');
 
-        return new Response(file_get_contents($contentPath));
+	if (!in_array($page, $allowedFiles)) {
+    	    throw $this->createNotFoundException();
+	}
+
+	$contentPath = __DIR__ . '/../../templates/legal/' . $page;
+	if (!file_exists($contentPath)) {
+    	    throw $this->createNotFoundException();
+	}
+
+	return new Response(file_get_contents($contentPath));
     }
 }


### PR DESCRIPTION
## Vulnerability fixed
- V-16: Local File Inclusion on /legal/content (BlogController.php)

## Problem
The 'p' parameter was directly concatenated to the file path,
allowing an attacker to read any file on the server using
path traversal (e.g. ../../../../etc/passwd).

## Fix
Replaced the dynamic path with a whitelist of allowed files.
Only terms.html, privacy.html and cookies.html are accessible.

## Tests performed
- /legal/content?p=../../../../etc/passwd → 404
- /legal/content?p=../../../.env → 404
- /legal/content?p=terms.html → works correctly
- No regression detected