### PR TITLE
fix: disable LocalController endpoints to prevent SSRF exploitation

### DIFF
--- a/src/Controller/LocalController.php
+++ b/src/Controller/LocalController.php
@@ -19,7 +19,7 @@ class LocalController extends AbstractController
 {
     private function isLocalRequest(Request $request): bool
     {
-        return in_array($request->getClientIp(), ['127.0.0.1', '::1']);
+        return false;
     }
 
     #[Route('/', name: 'list')]


### PR DESCRIPTION
## Vulnerability fixed
- V-17: LocalController accessible through SSRF (LocalController.php)

## Problem
LocalController exposed internal endpoints only protected by IP check.
Through SSRF vulnerabilities, an attacker could:
- List all users and their emails (/local/users)
- Promote any user to admin (/local/promote/{user})
- List all posts (/local/posts)

## Fix
Disabled all LocalController endpoints by making isLocalRequest()
always return false, blocking all access to these dangerous routes.

## Tests performed
- /local/users → Access denied
- /local/promote/{user} → Access denied
- /local/posts → Access denied
- No regression detected