### PR TITLE
fix: add access control check on admin role change endpoint

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -28,6 +28,9 @@ class AdminController extends AbstractController
     #[Route('/user/role/{user}', name: 'app_admin_role', methods: ['POST'])]
     public function changeRole(Request $request, UserRepository $userRepository, User $user): Response
     {
+        if (!$this->getUser() || !in_array('ROLE_ADMIN', $this->getUser()->getRoles())) {
+    	    throw $this->createAccessDeniedException('Access denied');
+	}
         $user = $userRepository->find($user);
         $user->setAdmin($request->get('role') === '1');
         $userRepository->save($user, true);


### PR DESCRIPTION
## Vulnerability fixed
- V-20: Missing access control on changeRole (AdminController.php)

## Problem
The changeRole endpoint had no verification that the logged-in
user was actually an admin, allowing any authenticated user
to change roles.

## Fix
Added a ROLE_ADMIN check at the beginning of the function,
throwing an AccessDeniedException if the user is not admin.

## Tests performed
- Regular user attempts to change role → Access denied
- Admin user changes role → works correctly
- No regression detected